### PR TITLE
Create a toggle for inspecting Immutable objects as JS

### DIFF
--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -132,7 +132,7 @@ class Bridge {
     this._wall.listen(this._handleMessage.bind(this));
   }
 
-  inspect(id: string, path: Array<string>, cb: (val: any) => any) {
+  inspect(id: string, path: Array<string>, immutablesAsJS: boolean, cb: (val: any) => any) {
     var _cid = this._cid++;
     this._cbs.set(_cid, (data, cleaned, proto, protoclean) => {
       if (cleaned.length) {
@@ -152,6 +152,7 @@ class Bridge {
       callback: _cid,
       path,
       id,
+      immutablesAsJS
     });
   }
 
@@ -259,7 +260,7 @@ class Bridge {
     }
 
     if (payload.type === 'inspect') {
-      this._inspectResponse(payload.id, payload.path, payload.callback);
+      this._inspectResponse(payload.id, payload.path, payload.immutablesAsJS, payload.callback);
       return;
     }
 
@@ -311,7 +312,7 @@ class Bridge {
     });
   }
 
-  _inspectResponse(id: string, path: Array<string>, callback: number) {
+  _inspectResponse(id: string, path: Array<string>, immutablesAsJS: boolean, callback: number) {
     var val = getIn(this._inspectables.get(id), path);
     var result = {};
     var cleaned = [];
@@ -321,7 +322,7 @@ class Bridge {
       var protod = false;
       var isFn = typeof val === 'function';
 
-      if (immutableUtils.isImmutable(val)) {
+      if (immutablesAsJS && immutableUtils.isImmutable(val)) {
         val = immutableUtils.shallowToJS(val);
       }
 

--- a/agent/consts.js
+++ b/agent/consts.js
@@ -16,6 +16,7 @@ module.exports = {
   name: Symbol('name'),
   type: Symbol('type'),
   inspected: Symbol('inspected'),
+  immutablesAsJS: Symbol('immutablesAsJS'),
   meta: Symbol('meta'),
   proto: Symbol('proto'),
 };

--- a/frontend/Container.js
+++ b/frontend/Container.js
@@ -67,7 +67,7 @@ class Container extends React.Component {
         <SplitPane
           initialWidth={300}
           left={() => <SearchPane reload={this.props.reload} />}
-          right={() => <PropState extraPanes={this.props.extraPanes} />}
+          right={() => <PropState reload={this.forceUpdate.bind(this)} extraPanes={this.props.extraPanes}/>}
         />
         <ContextMenu itemSources={[defaultItems, this.props.menuItems]} />
       </div>

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -72,8 +72,18 @@ class DataItem extends React.Component {
     this.state = {open: false, loading: false};
   }
 
+  shouldInspect(props) {
+    return (
+      props.value &&
+      (
+        props.value[consts.inspected] === false ||
+        props.value[consts.immutablesAsJS] !== props.immutablesAsJS
+      )
+    );
+  }
+
   componentWillReceiveProps(nextProps) {
-    if (this.state.open && nextProps.value && nextProps.value[consts.inspected] === false) {
+    if (this.state.open && this.shouldInspect(nextProps)) {
       this.inspect();
     }
   }
@@ -89,7 +99,7 @@ class DataItem extends React.Component {
     if (this.state.loading) {
       return;
     }
-    if (this.props.value && this.props.value[consts.inspected] === false) {
+    if (this.shouldInspect(this.props)) {
       this.inspect();
       return;
     }
@@ -140,6 +150,7 @@ class DataItem extends React.Component {
           <DataView
             data={this.props.value}
             path={this.props.path}
+            immutablesAsJS={this.props.immutablesAsJS}
             inspect={this.props.inspect}
             showMenu={this.props.showMenu}
             readOnly={this.props.readOnly}

--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -67,9 +67,12 @@ class PropState extends React.Component {
     var state = this.props.node.get('state');
     var context = this.props.node.get('context');
     var propsReadOnly = !this.props.node.get('canUpdate');
-
     return (
       <div style={styles.container}>
+        <div>
+          <input type='checkbox' checked={this.props.immutablesAsJS} onChange={this.props.onToggleImmutablesAsJS.bind(this)} id='immutables-as-js'/>
+          <label for='immutables-as-js'>Show Immutables as JS</label>
+        </div>
         <div style={styles.header}>
           <span style={styles.headerName}>
             &lt;{this.props.node.get('name')}&gt;
@@ -85,6 +88,7 @@ class PropState extends React.Component {
           <DataView
             path={['props']}
             readOnly={propsReadOnly}
+            immutablesAsJS={this.props.immutablesAsJS}
             inspect={this.props.inspect}
             showMenu={this.props.showMenu}
             key={this.props.id + '-props'}
@@ -98,6 +102,7 @@ class PropState extends React.Component {
             <DataView
               data={state}
               path={['state']}
+              immutablesAsJS={this.props.immutablesAsJS}
               inspect={this.props.inspect}
               showMenu={this.props.showMenu}
               key={this.props.id + '-state'}
@@ -110,6 +115,7 @@ class PropState extends React.Component {
             <DataView
               data={context}
               path={['context']}
+              immutablesAsJS={this.props.immutablesAsJS}
               inspect={this.props.inspect}
               showMenu={this.props.showMenu}
               key={this.props.id + '-context'}
@@ -131,14 +137,22 @@ var WrappedPropState = decorate({
     return ['selected', store.selected];
   },
 
+  shouldUpdate() {
+    return true;
+  },
+
   props(store) {
     var node = store.selected ? store.get(store.selected) : null;
     return {
       id: store.selected,
+      immutablesAsJS: store.immutablesAsJS,
       node,
       canEditTextContent: store.capabilities.editTextContent,
       onChangeText(text) {
         store.changeTextContent(store.selected, text);
+      },
+      onToggleImmutablesAsJS() {
+        store.toggleImmutablesAsJS(this.props.reload);
       },
       onChange(path, val) {
         if (path[0] === 'props') {


### PR DESCRIPTION
A new checkbox in PropState will toggle a flag within Store which will
dictate whether inspected Immutable objects should be inspected as
regular JS data (using immutableUtils)
